### PR TITLE
Reproduction: populating relation on loaded entity does not work

### DIFF
--- a/src/address.entity.ts
+++ b/src/address.entity.ts
@@ -1,0 +1,39 @@
+import { Entity, PrimaryKey, Property, OneToOne, OneToMany, ManyToOne } from "@mikro-orm/core";
+import { User } from "./user.entity";
+
+@Entity()
+export class City {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+
+@Entity()
+export class Address {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @OneToOne(() => User, (user: User) => user.address, { nullable: true, owner: false })
+  user?: User;
+
+  @ManyToOne(() => City)
+  city!: City;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}

--- a/src/user.entity.ts
+++ b/src/user.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryKey, Property, OneToOne } from "@mikro-orm/core";
+import { Address } from "./address.entity";
+
+@Entity()
+export class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @Property({ unique: true })
+  email: string;
+
+  @OneToOne(() => Address, { owner: true })
+  address!: Address;
+
+  constructor(name: string, email: string) {
+    this.name = name;
+    this.email = email;
+  }
+
+}


### PR DESCRIPTION
Hi @B4nan,

It seems that we are not able to properly populate an entity from a loaded entity relation.
Not sure it's a bug or a misuse of Mikro-ORM (sorry if it's a misuse).
Hope the repro is clear enough.

PS: I don't have the issue if I use `Ref` on my relations.

Best,
Lucas 