### PR TITLE
bug: not able to upsert when using custom type

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Martin Adamek",
   "license": "MIT",
   "dependencies": {
-    "@mikro-orm/core": "next",
-    "@mikro-orm/sqlite": "next",
+    "@mikro-orm/core": "^6.0.0",
+    "@mikro-orm/mysql": "^6.0.0",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {

--- a/src/point.type.ts
+++ b/src/point.type.ts
@@ -1,0 +1,45 @@
+import { Type } from "@mikro-orm/core";
+
+export class Point {
+
+  constructor(
+    public latitude: number,
+    public longitude: number,
+  ) {
+  }
+
+}
+
+export class PointType extends Type<Point | undefined, string | undefined> {
+
+  convertToDatabaseValue(value: Point | undefined): string | undefined {
+    if (!value) {
+      return value;
+    }
+
+    return `point(${value.latitude} ${value.longitude})`;
+  }
+
+  convertToJSValue(value: string | undefined): Point | undefined {
+    const m = value?.match(/point\((-?\d+(\.\d+)?) (-?\d+(\.\d+)?)\)/i);
+
+    if (!m) {
+      return undefined;
+    }
+
+    return new Point(+m[1], +m[3]);
+  }
+
+  convertToJSValueSQL(key: string) {
+    return `ST_AsText(${key})`;
+  }
+
+  convertToDatabaseValueSQL(key: string) {
+    return `ST_PointFromText(${key})`;
+  }
+
+  getColumnType(): string {
+    return 'point';
+  }
+
+}


### PR DESCRIPTION
Hi,

It seems that the upsert on entities using custom types is not working.

Here's a full repro using the Point custom type from the [documentation](https://mikro-orm.io/docs/custom-types#advanced-example---pointtype-and-wkt).

To be able to run the test on your machine, you need to have a MySQL instance running on 3306 with user root/root.

Any idea about the problem here?

Thanks!
Lucas