### PR TITLE
PopulateWhere with a $contains clause generates bad SQL for Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+﻿services:
+  database:
+    image: 'postgres:latest'
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: /usr/bin/pg_isready
+      interval: 5s
+      timeout: 10s
+      retries: 120
+    environment:
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: test-db
+      TZ: Europe/Athens

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Martin Adamek",
   "license": "MIT",
   "dependencies": {
-    "@mikro-orm/core": "next",
-    "@mikro-orm/sqlite": "next",
+    "@mikro-orm/core": "^6.4.3",
+    "@mikro-orm/postgresql": "^6.4.3",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -9,7 +9,8 @@ import {
   PrimaryKey,
   Property,
   Unique
-} from '@mikro-orm/sqlite';
+} from '@mikro-orm/core';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 
 export enum SchoolGrade {
   GradeOne = '1',
@@ -81,6 +82,18 @@ beforeAll(async () => {
     debug: ['query', 'query-params'],
     allowGlobalContext: true, // only for testing
   });
+
+  MikroORM.init({
+    host: '127.0.0.1',
+    dbName: 'test-db',
+    port: 5432,
+    user: 'username',
+    password: 'password',
+    driver: PostgreS,
+    entities: ['./dist/entities'],
+    entitiesTs: ['./src/entities'],
+    allowGlobalContext: true,
+  })
   await orm.schema.refreshDatabase();
 });
 

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -77,23 +77,17 @@ let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    dbName: ':memory:',
-    entities: [SubTestEntity, ExerciseEntity],
-    debug: ['query', 'query-params'],
-    allowGlobalContext: true, // only for testing
-  });
-
-  MikroORM.init({
     host: '127.0.0.1',
     dbName: 'test-db',
     port: 5432,
     user: 'username',
     password: 'password',
-    driver: PostgreS,
-    entities: ['./dist/entities'],
-    entitiesTs: ['./src/entities'],
+    driver: PostgreSqlDriver,
+    entities: [SubTestEntity, ExerciseEntity],
+    debug: ['query', 'query-params'],
     allowGlobalContext: true,
-  })
+  });
+
   await orm.schema.refreshDatabase();
 });
 

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,22 +1,75 @@
-import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
+import {
+  BaseEntity,
+  Cascade, Collection,
+  Entity,
+  Enum,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  Unique
+} from '@mikro-orm/sqlite';
 
-@Entity()
-class User {
+export enum SchoolGrade {
+  GradeOne = '1',
+  GradeTwo = '2',
+  GradeThree = '3',
+  GradeFour = '4',
+  GradeFive = '5',
+  GradeSix = '6',
+}
 
-  @PrimaryKey()
+export enum SubTestType {
+  AdjustVolume = 'adjustVolume',
+  CompareImages = 'compareImages',
+  CompareNumbers = 'compareNumbers',
+}
+
+@Entity({ tableName: 'subtests' })
+export class SubTestEntity {
+  @PrimaryKey({ type: 'number', autoincrement: true })
   id!: number;
 
   @Property()
-  name: string;
+  title!: string;
 
-  @Property({ unique: true })
-  email: string;
+  @Enum(() => SubTestType)
+  type!: SubTestType;
 
-  constructor(name: string, email: string) {
-    this.name = name;
-    this.email = email;
+  @Enum({ items: () => SchoolGrade, array: true })
+  grades!: SchoolGrade[];
+
+  @OneToMany(
+      () => ExerciseEntity,
+      (exercise: ExerciseEntity) => exercise.subtest,
+      {
+        cascade: [Cascade.ALL],
+        orderBy: { order: 'asc' },
+      },
+  )
+  exercises = new Collection<ExerciseEntity>(this);
+}
+
+@Entity({ tableName: 'exercises' })
+@Unique({ properties: ['order', 'subtest'] })
+export class ExerciseEntity extends BaseEntity {
+  @PrimaryKey({ type: 'number', autoincrement: true })
+  id!: number;
+
+  @Property()
+  order!: number;
+
+  @Enum({ items: () => SchoolGrade, array: true })
+  grades!: SchoolGrade[];
+
+  @ManyToOne(() => SubTestEntity)
+  subtest!: SubTestEntity;
+
+  @Property({ persist: true })
+  get type(): SubTestType {
+    return this.subtest.type;
   }
-
 }
 
 let orm: MikroORM;
@@ -24,7 +77,7 @@ let orm: MikroORM;
 beforeAll(async () => {
   orm = await MikroORM.init({
     dbName: ':memory:',
-    entities: [User],
+    entities: [SubTestEntity, ExerciseEntity],
     debug: ['query', 'query-params'],
     allowGlobalContext: true, // only for testing
   });
@@ -36,16 +89,36 @@ afterAll(async () => {
 });
 
 test('basic CRUD example', async () => {
-  orm.em.create(User, { name: 'Foo', email: 'foo' });
+  /* Create a Subtest for testing */
+  const subtest = new SubTestEntity();
+  subtest.title = 'Subtest One';
+  subtest.type = SubTestType.CompareImages;
+  subtest.grades = [SchoolGrade.GradeFour, SchoolGrade.GradeFive];
+  for (let i: number = 0; i < 5; i++) {
+    const exercise = new ExerciseEntity();
+    exercise.subtest = subtest;
+    exercise.order = i + 1;
+    exercise.grades = [SchoolGrade.GradeFour, SchoolGrade.GradeFive];
+    subtest.exercises.add(exercise);
+    orm.em.persist(exercise);
+  }
   await orm.em.flush();
-  orm.em.clear();
 
-  const user = await orm.em.findOneOrFail(User, { email: 'foo' });
-  expect(user.name).toBe('Foo');
-  user.name = 'Bar';
-  orm.em.remove(user);
-  await orm.em.flush();
+  const searchGrade: SchoolGrade = SchoolGrade.GradeFour;
 
-  const count = await orm.em.count(User, { email: 'foo' });
-  expect(count).toBe(0);
+  const results = await orm.em.find(SubTestEntity, {
+        grades: { $contains: [searchGrade] },
+      },
+      {
+        populate: ['exercises'],
+        populateWhere: {
+          exercises: {
+            grades: {
+              $contains: [searchGrade],
+            },
+          },
+        },
+      });
+
+  expect(results.length).toBe(1);
 });


### PR DESCRIPTION
I am using the `populate` options to fetch the relations on an Entity, both having a property of type `types.array`. 

While the `$contains` clause works well on the Entity itself, when I try and use it in the relations with the `populateWhere` clause, the resulting SQL misses the `{}` symbols that are required to denote an array.

My example requires Postgres, so I have included a `docker-compose.yml` file that you can run with:
```bash
$ docker compose up -d
```

When you run the test, you will see
```shell
DriverException: select "s0".*, "e1"."id" as "e1__id", "e1"."order" as "e1__order", "e1"."grades" as "e1__grades", "e1"."subtest_id" as "e1__subtest_id", "e1"."type" as "e1__type" from "subtests" as "s0" left join "exercises" as "e1" on "s0"."id" = "e1"."subtest_id" and "e1"."grades" @> '4' where "s0"."grades" @> '{4}' order by "e1"."order" asc - malformed array literal: "4"
 - detail: Array value must start with "{" or dimension information.
```