### PR TITLE
Moved "isolatedModules" to tsconfig.json

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,6 @@
 module.exports = {
   testTimeout: 30000,
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      // tsconfig: 'tsconfig.json',
-      isolatedModules: true,
-    }],
+    '^.+\\.tsx?$': ['ts-jest'],
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "isolatedModules": true
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
```
ts-jest[config] (WARN)
    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in /workspaces/reproduction/tsconfig.json instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules
```