### PR TITLE
Delete package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules
 sqlite.db
 dist
 temp
-package-lock.json


### PR DESCRIPTION
I don't think this file should be git-ignored. Without checking this in, two people could each clone this repo at different times and get different results (which IMO defeats the point of a reproduction)